### PR TITLE
sort uuids before training

### DIFF
--- a/src/datasets.py
+++ b/src/datasets.py
@@ -40,8 +40,8 @@ class CityFlowNLDataset(Dataset):
         self.random = Random
         with open(json_path) as f:
             tracks = json.load(f)
-        self.list_of_uuids = list(tracks.keys())
-        self.list_of_tracks = list(tracks.values())
+        self.list_of_uuids = sorted(list(tracks.keys()))
+        self.list_of_tracks = [tracks[i] for i in self.list_of_uuids]
         self.transform = transform
         self.bk_dic = {}
         self.bk_cache = mo_cache


### PR DESCRIPTION
- Added a simple fix by sorting the track ids.
- Note: if want to use a .txt file to store the order of track ids, it would be tricky because some other parts of the code have to be changed as well.

Resolves #22 