### PR TITLE
Add clip extractors

### DIFF
--- a/src/datasets.py
+++ b/src/datasets.py
@@ -11,6 +11,7 @@ from transformers import AutoTokenizer
 from typing import List 
 import numpy as np 
 import os.path as osp
+from src.extractors.clip.tokenization_clip import ClipTokenizer
 
 os.environ[
     "TOKENIZERS_PARALLELISM"
@@ -174,6 +175,189 @@ class CityFlowNLDataset(Dataset):
         )
         return batch_dict
 
+SPECIAL_TOKEN = {"CLS_TOKEN": "<|startoftext|>", "SEP_TOKEN": "<|endoftext|>",
+                              "MASK_TOKEN": "[MASK]", "UNK_TOKEN": "[UNK]", "PAD_TOKEN": "[PAD]"}
+
+@DATASET_REGISTRY.register()
+class CityFlowNLClipDataset(Dataset):
+    def __init__(
+        self,
+        data_cfg,
+        json_path,
+        transform=None,
+        flip_aug: bool = False,
+        num_texts_used: int = 3, 
+        use_other_views: bool = False,
+        max_words: int = 30,
+        tok_model_name='bpe',
+        **kwargs
+    ):
+        """
+        Dataset for training.
+        :param data_cfg: CfgNode for CityFlow NL.
+        """
+        self.data_cfg = data_cfg
+        self.crop_area = data_cfg["CROP_AREA"]
+        self.flip_aug = flip_aug
+        with open(json_path) as f:
+            tracks = json.load(f)
+        self.list_of_uuids = sorted(list(tracks.keys()))
+        self.list_of_tracks = [tracks[i] for i in self.list_of_uuids]
+        self.transform = transform
+        self.bk_dic = {}
+        self.max_words = max_words
+
+        self.num_texts_used = num_texts_used
+        self.use_other_views = use_other_views
+
+        self.tokenizer = ClipTokenizer(tok_model_name)
+        
+        print(len(self.list_of_uuids))
+        print("data load")
+
+    def __len__(self):
+        return len(self.list_of_uuids)
+
+    def get_text(self, caption):
+        # tokenize word
+        words = self.tokenizer.tokenize(caption)
+
+        # add cls token
+        words = [SPECIAL_TOKEN["CLS_TOKEN"]] + words
+        total_length_with_CLS = self.max_words - 1
+        if len(words) > total_length_with_CLS:
+            words = words[:total_length_with_CLS]
+
+        # add end token
+        words = words + [SPECIAL_TOKEN["SEP_TOKEN"]]
+
+        # convert token to id according to the vocab
+        input_ids = self.tokenizer.convert_tokens_to_ids(words)
+
+        # add zeros for feature of the same length
+        input_mask = [1] * len(input_ids)
+        segment_ids = [0] * len(input_ids)
+        while len(input_ids) < self.max_words:
+            input_ids.append(0)
+            input_mask.append(0)
+            segment_ids.append(0)
+
+        # ensure the length of feature to be equal with max words
+        assert len(input_ids) == self.max_words
+        assert len(input_mask) == self.max_words
+        assert len(segment_ids) == self.max_words
+        pairs_text = np.array(input_ids)
+        pairs_mask = np.array(input_mask)
+        pairs_segment = np.array(segment_ids)
+
+        return (
+          torch.from_numpy(pairs_text), 
+          torch.from_numpy(pairs_mask), 
+          torch.from_numpy(pairs_segment)
+        )
+
+    def __getitem__(self, index):
+
+        track_id = self.list_of_uuids[index]
+        track = self.list_of_tracks[index]
+        frame_idx = int(random.uniform(0, len(track["frames"])))
+        all_texts = track["nl"]
+        if self.use_other_views:
+            all_texts += track['nl_other_views']
+        random.shuffle(all_texts)
+        texts = np.random.choice(all_texts, size=min(len(all_texts), self.num_texts_used), replace=False)
+        text = '. '.join(texts)
+
+        is_flip = False
+        if self.flip_aug:
+            is_flip = np.random.rand() < 0.5
+            if is_flip:
+                text = (
+                    text.replace("left", "888888")
+                    .replace("right", "left")
+                    .replace("888888", "right")
+                )
+
+        # obtain text data
+        pairs_text, pairs_mask, pairs_segment = self.get_text(text)
+
+        frame_path = os.path.join(
+            self.data_cfg["CITYFLOW_PATH"], track["frames"][frame_idx]
+        )
+
+        frame = default_loader(frame_path)
+        box = track["boxes"][frame_idx]
+        if self.crop_area == 1.6666667:
+            box = (
+                int(box[0] - box[2] / 3.0),
+                int(box[1] - box[3] / 3.0),
+                int(box[0] + 4 * box[2] / 3.0),
+                int(box[1] + 4 * box[3] / 3.0),
+            )
+        else:
+            box = (
+                int(box[0] - (self.crop_area - 1) * box[2] / 2.0),
+                int(box[1] - (self.crop_area - 1) * box[3] / 2),
+                int(box[0] + (self.crop_area + 1) * box[2] / 2.0),
+                int(box[1] + (self.crop_area + 1) * box[3] / 2.0),
+            )
+
+        crop = frame.crop(box)
+        if self.transform is not None:
+            crop = self.transform(crop)
+            if self.flip_aug and is_flip:
+                crop = torch.flip(crop, [2])   
+
+        if self.data_cfg["USE_MOTION"]:
+            if self.list_of_uuids[index] in self.bk_dic:
+                bk = self.bk_dic[self.list_of_uuids[index]]
+            else:
+                bk = default_loader(
+                    self.data_cfg["MOTION_PATH"]
+                    + "/%s.jpg" % self.list_of_uuids[index]
+                )
+
+            bk = self.transform(bk)
+            if self.flip_aug and is_flip:
+                bk = torch.flip(bk, [2])
+
+
+        if self.data_cfg["USE_MOTION"]:
+            return {
+                'track_id': track_id,
+                'text': text,
+                'crop': crop,
+                'encoded_text': [pairs_text, pairs_mask, pairs_segment],
+                'instance_id': torch.tensor(index),
+                'motion': bk,
+            }
+        else:
+            return {
+                'track_id': track_id,
+                'text': text,
+                'crop': crop,
+                'encoded_text': [pairs_text, pairs_mask, pairs_segment],
+                'instance_id': torch.tensor(index),
+            }
+
+    def collate_fn(self, batch):
+        batch_dict = {
+            "images": torch.stack([x['crop'] for x in batch]),
+            "tokens": {
+              "input_ids": torch.stack([x['encoded_text'][0] for x in batch]),
+            },
+            "texts": [x['text'] for x in batch],
+            "car_ids": torch.stack([x['instance_id'] for x in batch]),
+            "query_ids": [x['track_id'] for x in batch],
+            "gallery_ids": [x['track_id'] for x in batch],
+            "target_ids": [x['track_id'] for x in batch],
+        }
+        if self.data_cfg["USE_MOTION"]:
+            batch_dict.update({
+              "motions": torch.stack([x['motion'] for x in batch])
+            })
+
+        return batch_dict
 
 
 class AIC22TextJsonDataset(Dataset):

--- a/src/extractors/__init__.py
+++ b/src/extractors/__init__.py
@@ -5,3 +5,4 @@ EXTRCT_REGISTRY = Registry("EXTRACTOR")
 from .eff_net import *
 from .senet import *
 from .hugging import *
+from .clip.clip_extractors import *

--- a/src/extractors/clip/clip_extractors.py
+++ b/src/extractors/clip/clip_extractors.py
@@ -1,0 +1,152 @@
+"""
+CLIP Encoders: From OpenAI: CLIP [https://github.com/openai/CLIP]
+"""
+
+from typing import Dict
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from .utils import CLIP
+
+from .. import EXTRCT_REGISTRY
+
+class ClipExtractorBase(nn.Module):
+    def __init__(
+        self, 
+        model_name: str = 'ViT-B/32',
+        **kwargs) -> None:
+        super().__init__()
+
+        clip_state_dict = CLIP.get_config(model_name=model_name)
+        self.clip, clip_embed_dim = self.load_config(clip_state_dict)
+        self.feature_dim = clip_embed_dim
+        self.dtype = self.clip.dtype
+
+    def load_config(self, clip_state_dict):
+
+        # set the parameters of CLIP
+        vision_width = clip_state_dict["visual.conv1.weight"].shape[0]
+        vision_layers = len(
+            [k for k in clip_state_dict.keys() if k.startswith("visual.") and k.endswith(".attn.in_proj_weight")])
+        vision_patch_size = clip_state_dict["visual.conv1.weight"].shape[-1]
+        grid_size = round((clip_state_dict["visual.positional_embedding"].shape[0] - 1) ** 0.5)
+        image_resolution = vision_patch_size * grid_size
+
+        embed_dim = clip_state_dict["text_projection"].shape[1]
+        context_length = clip_state_dict["positional_embedding"].shape[0]
+        vocab_size = 49408
+        transformer_width = clip_state_dict["ln_final.weight"].shape[0]
+        transformer_heads = transformer_width // 64
+        transformer_layers = len(set(k.split(".")[2] for k in clip_state_dict if k.startswith(f"transformer.resblocks")))
+
+        cut_top_layer = 0
+        
+        model = CLIP(
+            embed_dim,
+            image_resolution, vision_layers-cut_top_layer, vision_width, vision_patch_size,
+            context_length, vocab_size, transformer_width, transformer_heads, transformer_layers-cut_top_layer,
+        ).float()
+
+        ret = model.load_state_dict(clip_state_dict, strict=False)
+        return model, embed_dim
+
+@EXTRCT_REGISTRY.register()
+class ClipVideoExtractor(ClipExtractorBase):
+    
+    def __init__(self, model_name: str = 'ViT-B/32', **kwargs) -> None:
+        super().__init__(model_name=model_name)
+        self.model = self.clip.visual
+        self.clip = None
+
+    def mean_pooling(self, visual_output, video_mask):
+        """average pooling for the overall video representation
+        Args:
+            visual_output: embedding
+            video_mask: video embedding
+        Returns:
+            video_out: output embedding [1,512]
+        """
+        video_mask_un = video_mask.to(dtype=torch.float).unsqueeze(-1)
+        visual_output = visual_output * video_mask_un
+        video_mask_un_sum = torch.sum(video_mask_un, dim=1, dtype=torch.float)
+        video_mask_un_sum[video_mask_un_sum == 0.] = 1.
+        video_out = torch.sum(visual_output, dim=1) / video_mask_un_sum
+        return video_out
+
+    def forward(self, batch):
+        """video encoder
+        Returns:
+            x: output embedding [1,512]
+        """
+
+        video, video_mask = batch['videos'], batch['video_masks']
+        video_mask = video_mask.view(-1, video_mask.shape[-1])
+        video = torch.as_tensor(video).float()
+        bs, ts, channel, h, w = video.shape
+        video = video.view(bs * ts, channel, h, w)
+        video_frame = bs * ts
+
+        hidden = self.model(video.type(self.dtype), video_frame=video_frame)
+        hidden = self.model.ln_post(hidden) @ self.model.proj
+        visual_hidden = hidden[:, 0, :]
+        visual_hidden = visual_hidden.view(bs, -1, visual_hidden.size(-1))
+
+        # pooling
+        pooled_output = self.mean_pooling(visual_hidden, batch['video_masks'])
+
+        return pooled_output
+
+@EXTRCT_REGISTRY.register()
+class ClipImageExtractor(ClipExtractorBase):
+    
+    def __init__(self, model_name: str = 'ViT-B/32', **kwargs) -> None:
+        super().__init__(model_name=model_name)
+        self.model = self.clip.visual
+        self.clip = None
+        
+    def forward(self, x):
+        """video encoder
+        Returns:
+            x: output embedding [1,512]
+        """
+        hidden = self.model(x.type(self.dtype), video_frame=x.shape[0])
+        hidden = self.model.ln_post(hidden) @ self.model.proj
+        x = hidden[:, 0, :]
+        return x
+
+@EXTRCT_REGISTRY.register()
+class ClipTextExtractor(ClipExtractorBase):
+    
+    def __init__(self, model_name: str = 'ViT-B/32', **kwargs) -> None:
+        super().__init__(model_name=model_name)
+        self.model = self.clip.visual
+        self.token_embedding = self.clip.token_embedding
+        self.positional_embedding = self.clip.positional_embedding
+        self.transformer = self.clip.transformer
+        self.text_projection = self.clip.text_projection
+        self.ln_final = self.clip.ln_final
+        self.clip = None
+
+    def forward(self, batch):
+        """text encoder
+        Args:
+            text: caption
+            return_hidden: whether to return hidden variable
+        Returns:
+            x: output embedding [1,512]
+        """
+        x = self.token_embedding(batch["input_ids"]).type(self.dtype)  # [batch_size, n_ctx, d_model]
+
+        pos_emd = self.positional_embedding[:x.size(1), :].type(self.dtype)
+        x = x + pos_emd
+        x = x.permute(1, 0, 2)  # NLD -> LND
+        x = self.transformer(x)
+        x = x.permute(1, 0, 2)  # LND -> NLD
+
+        hidden = self.ln_final(x).type(self.dtype) @ self.text_projection
+
+        # x.shape = [batch_size, n_ctx, transformer.width]
+        # take features from the eot embedding (eot_token is the highest number in each sequence)
+        x = hidden[torch.arange(hidden.shape[0]), batch["input_ids"].argmax(dim=-1)]
+
+        return x

--- a/src/extractors/clip/tokenization_clip.py
+++ b/src/extractors/clip/tokenization_clip.py
@@ -1,0 +1,154 @@
+import gzip
+import html
+import os
+from functools import lru_cache
+
+import ftfy
+import regex as re
+from src.utils.download import download_url
+
+
+PRETRAINED = {
+    'bpe': "https://github.com/CryhanFang/CLIP2Video/raw/main/modules/bpe_simple_vocab_16e6.txt.gz"
+}
+
+@lru_cache()
+def default_bpe():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "bpe_simple_vocab_16e6.txt.gz")
+
+
+@lru_cache()
+def bytes_to_unicode():
+    """
+    Returns list of utf-8 byte and a corresponding list of unicode strings.
+    The reversible bpe codes work on unicode strings.
+    This means you need a large # of unicode characters in your vocab if you want to avoid UNKs.
+    When you're at something like a 10B token dataset you end up needing around 5K for decent coverage.
+    This is a signficant percentage of your normal, say, 32K bpe vocab.
+    To avoid that, we want lookup tables between utf-8 bytes and unicode strings.
+    And avoids mapping to whitespace/control characters the bpe code barfs on.
+    """
+    bs = list(range(ord("!"), ord("~")+1))+list(range(ord("¡"), ord("¬")+1))+list(range(ord("®"), ord("ÿ")+1))
+    cs = bs[:]
+    n = 0
+    for b in range(2**8):
+        if b not in bs:
+            bs.append(b)
+            cs.append(2**8+n)
+            n += 1
+    cs = [chr(n) for n in cs]
+    return dict(zip(bs, cs))
+
+
+def get_pairs(word):
+    """Return set of symbol pairs in a word.
+    Word is represented as tuple of symbols (symbols being variable-length strings).
+    """
+    pairs = set()
+    prev_char = word[0]
+    for char in word[1:]:
+        pairs.add((prev_char, char))
+        prev_char = char
+    return pairs
+
+
+def basic_clean(text):
+    text = ftfy.fix_text(text)
+    text = html.unescape(html.unescape(text))
+    return text.strip()
+
+
+def whitespace_clean(text):
+    text = re.sub(r'\s+', ' ', text)
+    text = text.strip()
+    return text
+
+
+class ClipTokenizer(object):
+    def __init__(self, tok_name: str = None):
+        if tok_name in PRETRAINED.keys():
+            bpe_path = download_url(PRETRAINED[tok_name], root='pretrained')
+        else:
+            raise ValueError()
+        self.byte_encoder = bytes_to_unicode()
+        self.byte_decoder = {v: k for k, v in self.byte_encoder.items()}
+        merges = gzip.open(bpe_path).read().decode("utf-8").split('\n')
+        merges = merges[1:49152-256-2+1]
+        merges = [tuple(merge.split()) for merge in merges]
+        vocab = list(bytes_to_unicode().values())
+        vocab = vocab + [v+'</w>' for v in vocab]
+        for merge in merges:
+            vocab.append(''.join(merge))
+        vocab.extend(['<|startoftext|>', '<|endoftext|>'])
+        self.encoder = dict(zip(vocab, range(len(vocab))))
+        self.decoder = {v: k for k, v in self.encoder.items()}
+        self.bpe_ranks = dict(zip(merges, range(len(merges))))
+        self.cache = {'<|startoftext|>': '<|startoftext|>', '<|endoftext|>': '<|endoftext|>'}
+        self.pat = re.compile(r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+""", re.IGNORECASE)
+
+        self.vocab = self.encoder
+
+    def bpe(self, token):
+        if token in self.cache:
+            return self.cache[token]
+        word = tuple(token[:-1]) + ( token[-1] + '</w>',)
+        pairs = get_pairs(word)
+
+        if not pairs:
+            return token+'</w>'
+
+        while True:
+            bigram = min(pairs, key = lambda pair: self.bpe_ranks.get(pair, float('inf')))
+            if bigram not in self.bpe_ranks:
+                break
+            first, second = bigram
+            new_word = []
+            i = 0
+            while i < len(word):
+                try:
+                    j = word.index(first, i)
+                    new_word.extend(word[i:j])
+                    i = j
+                except:
+                    new_word.extend(word[i:])
+                    break
+
+                if word[i] == first and i < len(word)-1 and word[i+1] == second:
+                    new_word.append(first+second)
+                    i += 2
+                else:
+                    new_word.append(word[i])
+                    i += 1
+            new_word = tuple(new_word)
+            word = new_word
+            if len(word) == 1:
+                break
+            else:
+                pairs = get_pairs(word)
+        word = ' '.join(word)
+        self.cache[token] = word
+        return word
+
+    def encode(self, text):
+        bpe_tokens = []
+        text = whitespace_clean(basic_clean(text)).lower()
+        for token in re.findall(self.pat, text):
+            token = ''.join(self.byte_encoder[b] for b in token.encode('utf-8'))
+            bpe_tokens.extend(self.encoder[bpe_token] for bpe_token in self.bpe(token).split(' '))
+        return bpe_tokens
+
+    def decode(self, tokens):
+        text = ''.join([self.decoder[token] for token in tokens])
+        text = bytearray([self.byte_decoder[c] for c in text]).decode('utf-8', errors="replace").replace('</w>', ' ')
+        return text
+
+    def tokenize(self, text):
+        tokens = []
+        text = whitespace_clean(basic_clean(text)).lower()
+        for token in re.findall(self.pat, text):
+            token = ''.join(self.byte_encoder[b] for b in token.encode('utf-8'))
+            tokens.extend(bpe_token for bpe_token in self.bpe(token).split(' '))
+        return tokens
+
+    def convert_tokens_to_ids(self, tokens):
+        return [self.encoder[bpe_token] for bpe_token in tokens]

--- a/src/extractors/clip/utils.py
+++ b/src/extractors/clip/utils.py
@@ -1,0 +1,358 @@
+#coding:utf-8
+# @Time : 2021/6/19
+# @File: module_clip.py
+# @Version: version 1.0
+# Adapted from: https://github.com/openai/CLIP/blob/main/clip/clip.py
+
+from collections import OrderedDict
+import os
+from src.utils.download import download_url
+
+import torch
+from torch import nn
+
+
+# if the pretrained model doesn't exist, please download the model from the link of openai
+# in this project, we adopt ViT-B/32 for pre-training
+_MODELS = {
+    "RN50": "https://openaipublic.azureedge.net/clip/models/afeb0e10f9e5a86da6080e35cf09123aca3b358a0c3e3b6c78a7b63bc04b6762/RN50.pt",
+    "RN101": "https://openaipublic.azureedge.net/clip/models/8fa8567bab74a42d41c5915025a8e4538c3bdbe8804a470a72f30b0d94fab599/RN101.pt",
+    "RN50x4": "https://openaipublic.azureedge.net/clip/models/7e526bd135e493cef0776de27d5f42653e6b4c8bf9e0f653bb11773263205fdd/RN50x4.pt",
+    "ViT-B/32": "https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt",
+}
+
+def available_models():
+    """Returns the names of available CLIP models"""
+    return list(_MODELS.keys())
+
+
+
+class LayerNorm(nn.LayerNorm):
+    """Subclass torch's LayerNorm to handle fp16."""
+
+    def forward(self, x):
+        orig_type = x.dtype
+        ret = super().forward(x.type(torch.float32))
+        return ret.type(orig_type)
+
+
+class QuickGELU(nn.Module):
+    def forward(self, x):
+        return x * torch.sigmoid(1.702 * x)
+
+
+class ResidualAttentionBlock(nn.Module):
+    """residual attention block used in transformer
+
+     Attributes:
+         attn: multi-head attention
+         ln_1: layer normalization
+         mlp: MLP
+         ln_2: layer normalization
+         attn_mask: attention mask
+     """
+
+    def __init__(self, d_model, n_head, attn_mask=None):
+        super().__init__()
+
+        self.attn = nn.MultiheadAttention(d_model, n_head)
+        self.ln_1 = LayerNorm(d_model)
+        self.mlp = nn.Sequential(OrderedDict([
+            ("c_fc", nn.Linear(d_model, d_model * 4)),
+            ("gelu", QuickGELU()),
+            ("c_proj", nn.Linear(d_model * 4, d_model))
+        ]))
+        self.ln_2 = LayerNorm(d_model)
+        self.attn_mask = attn_mask
+
+    def attention(self, x):
+        attn_mask_ = self.attn_mask
+        if self.attn_mask is not None and hasattr(self.attn_mask, '__call__'):
+            attn_mask_ = self.attn_mask(x.size(0))   # LND
+
+        attn_mask_ = attn_mask_.to(dtype=x.dtype, device=x.device) if attn_mask_ is not None else None
+        return self.attn(x, x, x, need_weights=False, attn_mask=attn_mask_)[0]
+
+    def forward(self, x_tuple):
+        x, video_frame = x_tuple
+        x = x + self.attention(self.ln_1(x))
+        x = x + self.mlp(self.ln_2(x))
+        return (x, video_frame)
+
+
+class Transformer(nn.Module):
+    """basic transformer
+
+    Attributes:
+        width: dimension for the output of every layer
+        layers: total number of layers
+        resblocks: residual block
+    """
+
+    def __init__(self, width, layers, heads, attn_mask = None):
+        super().__init__()
+        self.width = width
+        self.layers = layers
+        self.resblocks = nn.Sequential(*[ResidualAttentionBlock(width, heads, attn_mask) for _ in range(layers)])
+
+    def forward(self, x, video_frame=-1):
+        return self.resblocks((x, video_frame))[0]
+
+
+class VisualTransformer(nn.Module):
+    """basic vision transformer
+
+    Attributes:
+        input_resolution: input resolution of image
+        patch_size: patch size to split image
+        width: dimension for the output of every layer
+        layers: total number of layers
+        heads: head for multi-head attention
+        output_dim: the final output of ViT
+    """
+
+    def __init__(self, input_resolution, patch_size, width, layers, heads, output_dim):
+
+        super().__init__()
+        self.input_resolution = input_resolution
+        self.output_dim = output_dim
+
+        self.conv1 = nn.Conv2d(in_channels=3, out_channels=width, kernel_size=patch_size, stride=patch_size, bias=False)
+
+        scale = width ** -0.5
+        self.class_embedding = nn.Parameter(scale * torch.randn(width))
+        self.positional_embedding = nn.Parameter(scale * torch.randn((input_resolution // patch_size) ** 2 + 1, width))
+        self.ln_pre = LayerNorm(width)
+
+        self.transformer = Transformer(width, layers, heads)
+
+        self.ln_post = LayerNorm(width)
+        self.proj = nn.Parameter(scale * torch.randn(width, output_dim))
+
+
+    def forward(self, x, video_frame=-1):
+
+        x = self.conv1(x)  # shape = [*, width, grid, grid]
+
+        x = x.reshape(x.shape[0], x.shape[1], -1)  # shape = [*, width, grid ** 2]
+        x = x.permute(0, 2, 1)  # shape = [*, grid ** 2, width]
+        x = torch.cat(
+            [self.class_embedding.to(x.dtype) + torch.zeros(x.shape[0], 1, x.shape[-1], dtype=x.dtype, device=x.device),
+             x], dim=1)  # shape = [*, grid ** 2 + 1, width]
+        x = x + self.positional_embedding.to(x.dtype)
+        x = self.ln_pre(x)
+
+        x = x.permute(1, 0, 2)  # NLD -> LND
+        x = self.transformer(x, video_frame=video_frame)
+        x = x.permute(1, 0, 2)  # LND -> NLD
+
+        # Move the three lines below to `encode_image` for entire hidden sequence
+        # x = self.ln_post(x[:, 0, :])
+        # if self.proj is not None:
+        #     x = x @ self.proj
+
+        return x
+
+
+class CLIP(nn.Module):
+    """basic CLIP model
+
+    Attributes:
+        input_resolution: input resolution of image
+        patch_size: patch size to split image
+        width: dimension for the output of every layer
+        layers: total number of layers
+        heads: head for multi-head attention
+        output_dim: the final output of ViT
+    """
+    def __init__(self,
+                 embed_dim,
+                 # vision
+                 image_resolution,
+                 vision_layers,
+                 vision_width,
+                 vision_patch_size,
+                 # text
+                 context_length,
+                 vocab_size,
+                 transformer_width,
+                 transformer_heads,
+                 transformer_layers,
+                 ):
+        super().__init__()
+
+        # the length of caption
+        self.context_length = context_length
+
+        # set vision transformer
+        vision_heads = vision_width // 64
+        self.visual = VisualTransformer(
+            input_resolution=image_resolution,
+            patch_size=vision_patch_size,
+            width=vision_width,
+            layers=vision_layers,
+            heads=vision_heads,
+            output_dim=embed_dim
+        )
+
+        # set the text transformer
+        self.transformer = Transformer(
+            width=transformer_width,
+            layers=transformer_layers,
+            heads=transformer_heads,
+            attn_mask=self.build_attention_mask
+        )
+
+        self.vocab_size = vocab_size
+        self.token_embedding = nn.Embedding(vocab_size, transformer_width)
+        self.positional_embedding = nn.Parameter(torch.empty(self.context_length, transformer_width))
+        self.ln_final = LayerNorm(transformer_width)
+
+        self.text_projection = nn.Parameter(torch.empty(transformer_width, embed_dim))
+        self.logit_scale = nn.Parameter(torch.ones([]))
+
+        self.initialize_parameters()
+
+    def initialize_parameters(self):
+        nn.init.normal_(self.token_embedding.weight, std=0.02)
+        nn.init.normal_(self.positional_embedding, std=0.01)
+
+        proj_std = (self.transformer.width ** -0.5) * ((2 * self.transformer.layers) ** -0.5)
+        attn_std = self.transformer.width ** -0.5
+        fc_std = (2 * self.transformer.width) ** -0.5
+        for block in self.transformer.resblocks:
+            nn.init.normal_(block.attn.in_proj_weight, std=attn_std)
+            nn.init.normal_(block.attn.out_proj.weight, std=proj_std)
+            nn.init.normal_(block.mlp.c_fc.weight, std=fc_std)
+            nn.init.normal_(block.mlp.c_proj.weight, std=proj_std)
+
+        if self.text_projection is not None:
+            nn.init.normal_(self.text_projection, std=self.transformer.width ** -0.5)
+
+    @staticmethod
+    def get_config(model_name='ViT-B/32'):
+
+        if model_name in _MODELS.keys():
+            clip_path = download_url(_MODELS[model_name], root='pretrained')
+        else:
+            raise RuntimeError(f"Model ViT-B/32 not found; available models = {available_models()}")
+
+        try:
+            # loading JIT archive
+            model = torch.jit.load(clip_path, map_location="cpu").eval()
+            state_dict = model.state_dict()
+        except RuntimeError:
+            state_dict = torch.load(clip_path, map_location="cpu")
+
+        return state_dict
+
+    def build_attention_mask(self, context_length):
+        """build attention mask for text
+        Args:
+            context_length: length of caption
+        Returns:
+            mask: the constructed mask
+        """
+        mask = torch.zeros(context_length, context_length)
+        mask.fill_(float("-inf"))
+        mask.triu_(1)  # zero out the lower diagonal
+        return mask
+
+    @property
+    def dtype(self):
+        return self.visual.conv1.weight.dtype
+
+    def encode_image(self, image, return_hidden=False, video_frame=-1):
+        """image encoder
+        Args:
+            image: image
+            return_hidden: whether to return hidden variable
+            video_frame: frame length of video
+        Returns:
+            x: output embedding [1,512]
+        """
+        hidden = self.visual(image.type(self.dtype), video_frame=video_frame)
+        hidden = self.visual.ln_post(hidden) @ self.visual.proj
+
+        x = hidden[:, 0, :]
+
+        if return_hidden:
+            return x, hidden
+
+        return x
+
+    def encode_text(self, text, return_hidden=False):
+        """text encoder
+        Args:
+            text: caption
+            return_hidden: whether to return hidden variable
+        Returns:
+            x: output embedding [1,512]
+        """
+        x = self.token_embedding(text).type(self.dtype)  # [batch_size, n_ctx, d_model]
+
+        pos_emd = self.positional_embedding[:x.size(1), :].type(self.dtype)
+        x = x + pos_emd
+        x = x.permute(1, 0, 2)  # NLD -> LND
+        x = self.transformer(x)
+        x = x.permute(1, 0, 2)  # LND -> NLD
+
+        hidden = self.ln_final(x).type(self.dtype) @ self.text_projection
+
+        # x.shape = [batch_size, n_ctx, transformer.width]
+        # take features from the eot embedding (eot_token is the highest number in each sequence)
+        x = hidden[torch.arange(hidden.shape[0]), text.argmax(dim=-1)]
+
+        if return_hidden:
+            return x, hidden
+
+        return x
+
+    def forward(self, image, text):
+        """forward method for CLIP
+        Args:
+            image: image
+            text: caption
+        Returns:
+            logits_per_image: image-to-text similarity
+            logits_per_text: text-to-image similarity
+        """
+
+        image_features = self.encode_image(image)
+        text_features = self.encode_text(text)
+
+        # normalized features
+        image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+        text_features = text_features / text_features.norm(dim=-1, keepdim=True)
+
+        # cosine similarity as logit
+        logit_scale = self.logit_scale.exp()
+        logits_per_image = logit_scale * image_features @ text_features.t()
+        logits_per_text = logit_scale * text_features @ image_features.t()
+
+        # shape = [global_batch_size, global_batch_size]
+        return logits_per_image, logits_per_text
+
+
+def convert_weights(model: nn.Module):
+    """Convert applicable model parameters to fp16"""
+
+    def _convert_weights_to_fp16(l):
+        if isinstance(l, (nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.Linear)):
+            l.weight.data = l.weight.data.half()
+            if l.bias is not None:
+                l.bias.data = l.bias.data.half()
+
+        if isinstance(l, nn.MultiheadAttention):
+            for attr in [*[f"{s}_proj_weight" for s in ["in", "q", "k", "v"]], "in_proj_bias", "bias_k", "bias_v"]:
+                tensor = getattr(l, attr)
+                if tensor is not None:
+                    tensor.data = tensor.data.half()
+
+        for name in ["text_projection", "proj"]:
+            if hasattr(l, name):
+                attr = getattr(l, name)
+                if attr is not None:
+                    attr.data = attr.data.half()
+
+    model.apply(_convert_weights_to_fp16)

--- a/src/extractors/hugging.py
+++ b/src/extractors/hugging.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 
 from transformers import (
@@ -48,5 +49,6 @@ class LangExtractor(ExtractorNetwork):
             input_ids=input_ids, attention_mask=attention_mask
         )
         feature = transformer_out.last_hidden_state
+        feature = torch.mean(feature, dim=1)
 
         return feature

--- a/src/models/abstract.py
+++ b/src/models/abstract.py
@@ -27,9 +27,10 @@ class AICBase(pl.LightningModule):
 
     def setup(self, stage: str):
         if stage != "predict":
+            image_size = self.cfg["data"]["args"]["SIZE"]
             image_transform = torchvision.transforms.Compose(
                 [
-                    torchvision.transforms.Resize((288, 288)),
+                    torchvision.transforms.Resize((image_size, image_size)),
                     torchvision.transforms.ToTensor(),
                     torchvision.transforms.Normalize(
                         mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]

--- a/src/models/siamese.py
+++ b/src/models/siamese.py
@@ -29,10 +29,12 @@ class UTS(AICBase):
         )(**self.cfg.extractors["img_encoder"]["args"])
 
         self.img_in_dim = self.visualExtrct.feature_dim
+        self.img_in_dim_bk = self.visualExtrctBK.feature_dim
+        self.text_in_dim = self.nlangExtrct.feature_dim
 
         # Define the latent adaptation for visual backbones
         self.domian_vis_fc = nn.Linear(self.img_in_dim, embed_dim)
-        self.domian_vis_fc_bk = nn.Linear(self.img_in_dim, embed_dim)
+        self.domian_vis_fc_bk = nn.Linear(self.img_in_dim_bk, embed_dim)
 
         # Something something
         self.domian_vis_fc_merge = nn.Sequential(
@@ -55,8 +57,8 @@ class UTS(AICBase):
         )
 
         self.domian_lang_fc = nn.Sequential(
-            nn.LayerNorm(embed_dim),
-            nn.Linear(embed_dim, embed_dim),
+            nn.LayerNorm(self.text_in_dim),
+            nn.Linear(self.text_in_dim, embed_dim),
             nn.ReLU(),
             nn.Linear(embed_dim, embed_dim),
         )
@@ -85,8 +87,7 @@ class UTS(AICBase):
 
     def encode_nlang_feats(self, batch):
         assert "tokens" in batch.keys(), "Input dict must contain tokens"
-        nlang_embeddings = self.nlangExtrct(batch["tokens"])
-        lang_embeds = torch.mean(nlang_embeddings, dim=1)
+        lang_embeds = self.nlangExtrct(batch['tokens'])
         lang_embeds = self.domian_lang_fc(lang_embeds)
         return lang_embeds
 

--- a/src/utils/download.py
+++ b/src/utils/download.py
@@ -1,0 +1,33 @@
+import os
+import os.path as osp
+import urllib.request as urlreq
+
+def download_url(url, root, filename=None):
+    """Download a file from a url and place it in root.
+    Args:
+        url (str): URL to download file from
+        root (str): Directory to place downloaded file in
+        filename (str, optional): Name to save the file under. If None, use the basename of the URL
+    """
+
+    root = os.path.expanduser(root)
+    if not filename:
+        filename = os.path.basename(url)
+    fpath = os.path.join(root, filename)
+
+    if osp.isfile(fpath):
+        return fpath
+
+    os.makedirs(root, exist_ok=True)
+
+    try:
+        print('Downloading ' + url + ' to ' + fpath)
+        urlreq.urlretrieve(url, fpath)
+    except (urlreq.error.URLError, IOError) as e:
+        if url[:5] == 'https':
+            url = url.replace('https:', 'http:')
+            print('Failed download. Trying https -> http instead.'
+                    ' Downloading ' + url + ' to ' + fpath)
+            urlreq.urlretrieve(url, fpath)
+
+    return fpath


### PR DESCRIPTION
Resolves #35 

- Add new `CityFlowNLClipDataset` in `dataset.py`, this class is for processing data into clip inputs format (a different tokenizer must be used).
- Add 3 new extractors in `clip_extractors.py` which are `ClipImageExtractor`,  `ClipVideoExtractor` and  `ClipTextExtractor` , they automatically load in pretrained VIT-B/32. Can be plugged in UTS, I had to change some line in UTS to accomplish this though.
- Wandb log [here](https://wandb.ai/hcmus-aic22-ver/aic/runs/1xwhzgvl). It has not converged yet, but it was slower than the original UTS.
- Have written test cases for this.
- To use this, simply change the yaml config. For example:

```yaml
data:
  name: CityFlowNLClipDataset
  args:
    CITYFLOW_PATH: /content/AIC2022-VER/data/extracted_frames
    SIZE: 224
    CROP_AREA: 1.0 ## new_= CROP_AREA * old_w
    TEST_TRACKS_JSON_PATH: /content/AIC2022-VER/data/test_tracks.json
    USE_MOTION: True
    MOTION_PATH: /content/AIC2022-VER/data/motion_map
    train:
      json_path: /content/AIC2022-VER/data/split/train.json
      flip_aug: True
      num_texts_used: 5
      use_other_views: True
      max_words: 30
      loader:
        batch_size: 32
        num_workers: 2
        shuffle: True
        drop_last: False
    val:
      json_path: /content/AIC2022-VER/data/split/val.json
      flip_aug: False
      num_texts_used: 3
      use_other_views: False
      max_words: 30
      loader:
        batch_size: 32
        num_workers: 2
        shuffle: False
        drop_last: False
extractors:
  img_encoder:
    name: ClipImageExtractor
    args:
      model_name: ViT-B/32
  lang_encoder:
    name: ClipTextExtractor
    args:
      pretrained: bpe
      model_name: ViT-B/32
```